### PR TITLE
typo and markdown linting corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ This is the source code for my Manning book _Learn Docker in a Month of Lunches_
 
 ## Elevator Pitch
 
-Go from zero to production readiness with Docker in 21 bite-sized lessons! _Learn Docker in a Month of Lunches_ is an accessible task-focused guide to Docker on Linux, Windows, or Mac systems. 
+Go from zero to production readiness with Docker in 21 bite-sized lessons! _Learn Docker in a Month of Lunches_ is an accessible task-focused guide to Docker on Linux, Windows, or Mac systems.
 
-In it you'll learn practical Docker skills to help you tackle the challenges of modern IT, from cloud migration and microservices to handling legacy systems. 
+In it you'll learn practical Docker skills to help you tackle the challenges of modern IT, from cloud migration and microservices to handling legacy systems.
 
 There's no excessive theory or niche-use cases - just a quick-and-easy guide to the essentials of Docker you'll use every day.
 
 ## A Note About Tech Accessibility
 
-One important thing about Learn Docker in a Month of Lunches: I want it to be as accessible as possible. Too many Docker books assume that you're a Linux guru, and they give you exercises that work only on Intel machines and make sense only if you've spent years working as a sysadmin. 
+One important thing about Learn Docker in a Month of Lunches: I want it to be as accessible as possible. Too many Docker books assume that you're a Linux guru, and they give you exercises that work only on Intel machines and make sense only if you've spent years working as a sysadmin.
 
-This book is different. All the code samples and exercises are cross-platform and work on Windows, Mac, Linux, Intel, and Arm. You should be able to follow along with Windows 10 on your desktop, OSX on your MacBook, or Debian on your Raspberry Pi. 
+This book is different. All the code samples and exercises are cross-platform and work on Windows, Mac, Linux, Intel, and Arm. You should be able to follow along with Windows 10 on your desktop, OSX on your MacBook, or Debian on your Raspberry Pi.
 
 I've also tried hard to assume a minimum amount of background knowledge — Docker crosses the boundaries of architecture, development, and operations, and I've tried to do the same. This book should work for you whatever your background in IT.
 

--- a/ch02/exercises/hello-diamol-web/README.md
+++ b/ch02/exercises/hello-diamol-web/README.md
@@ -1,2 +1,1 @@
 # hello-diamol-web
-

--- a/ch02/exercises/hello-diamol/README.md
+++ b/ch02/exercises/hello-diamol/README.md
@@ -1,5 +1,5 @@
 
-0. Build and pash the arch images
+0. Build and push the arch images
 
 1. Enable experimental in `~/.docker/config.json`:
 
@@ -9,7 +9,7 @@
 }
 ```
 
-2. Create the manifest list (multi-rach name followed by individual image names):
+2. Create the manifest list (multi-arch name followed by individual image names):
 
 ```
 docker manifest create `

--- a/ch02/exercises/hello-diamol/linux/cmd.sh
+++ b/ch02/exercises/hello-diamol/linux/cmd.sh
@@ -4,7 +4,7 @@ echo ---------------------
 echo My name is:
 echo $(hostname)
 echo ---------------------
-echo I''m running on:
+echo "I'm running on:"
 echo $(uname -s -r -m)
 echo ---------------------
 echo My address is:

--- a/ch03/lab/README.md
+++ b/ch03/lab/README.md
@@ -2,14 +2,14 @@
 
 docker container run -it --name ch03lab diamol/ch03-lab
 
-echo Elton >> ch03.txt 
+echo Elton >> ch03.txt
 
 exit
 
 docker container commit ch03lab ch03-lab-soln
-      
+
 docker container run ch03-lab-soln cat ch03.txt
 
-OR 
+OR
 
 docker container run ch03-lab-soln cmd /s /c type ch03.txt

--- a/ch04/lab/README.md
+++ b/ch04/lab/README.md
@@ -1,6 +1,7 @@
 # DIAMOL Chapter 4 Lab - Sample Solution
 
 ## Before
+
 docker image build -t ch04-lab .
 
 docker container run -d -p 804:80 ch04-lab
@@ -8,6 +9,7 @@ docker container run -d -p 804:80 ch04-lab
 image is 800MB on Linux; 5.2GB on Windows
 
 ## After
+
 docker image build -t ch04-lab:optimized -f Dockerfile.optimized .
 
 docker container run -d -p 805:80 ch04-lab:optimized
@@ -18,7 +20,7 @@ image is 15MB on Linux; 230MB on Windows
 
 ```
 >docker image ls ch04*
-REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE 
+REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 ch04-lab            optimized           acd8afedcb0d        16 minutes ago      15.3MB
 ch04-lab            latest              87d6bce2a950        19 minutes ago      802MB
 ```

--- a/ch05/lab/README.md
+++ b/ch05/lab/README.md
@@ -10,7 +10,7 @@ docker image push registry.local:5000/gallery/ui
 
 > Pushes all tags for the repo
 
-## Check 
+## Check
 
 ```
 curl http://registry.local:5000/v2/gallery/ui/tags/list
@@ -25,7 +25,7 @@ curl --head \
 ```
 > Output headers include `Docker-Content-Digest`, this is the manifest you need
 
-e.g. 
+e.g.
 
 ```
 Docker-Content-Digest: sha256:127d0ed6f7a8d148a39b7ea168c083694d030e2bffbda60cb53057e731114fbb
@@ -38,7 +38,7 @@ curl -X DELETE \
   http://registry.local:5000/v2/gallery/ui/manifests/sha256:127d0ed6f7a8d148a39b7ea168c083694d030e2bffbda60cb53057e731114fbb
 ```
 
-## Check 
+## Check
 
 ```
 curl http://registry.local:5000/v2/gallery/ui/tags/list

--- a/ch06/lab/README.md
+++ b/ch06/lab/README.md
@@ -26,7 +26,7 @@ Let's create a volume to use for storing the database file instead:
 docker volume create ch06-lab
 ```
 
-You can create a configuration file which specifies a different path for the database file, and that path can be your volume mount. 
+You can create a configuration file which specifies a different path for the database file, and that path can be your volume mount.
 
 My [config.json](./solution/config.json) configures the app to write the database file in `/new-data`.
 


### PR DESCRIPTION
correcting a couple of typos as well as a few things the markdown linter complained about:

- extra spaces at EOL
- missing blanks at EOF
- blank lines around headers