### PR TITLE
ch04: Fixing package paths and addings imports

### DIFF
--- a/ch04/exercises/image-of-the-day/src/main/java/iotd/configuration/BeanConfiguration.java
+++ b/ch04/exercises/image-of-the-day/src/main/java/iotd/configuration/BeanConfiguration.java
@@ -1,6 +1,9 @@
-package iotd;
+package iotd.configuration;
 
 import org.springframework.context.annotation.Bean;
+
+import iotd.services.CacheService;
+import iotd.services.MemoryCacheService;
 
 public class BeanConfiguration {
 

--- a/ch04/exercises/image-of-the-day/src/main/java/iotd/controllers/ImageController.java
+++ b/ch04/exercises/image-of-the-day/src/main/java/iotd/controllers/ImageController.java
@@ -1,4 +1,4 @@
-package iotd;
+package iotd.controllers;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
+
+import iotd.models.ApodImage;
+import iotd.models.Image;
+import iotd.services.CacheService;
 
 @RestController
 public class ImageController {

--- a/ch04/exercises/image-of-the-day/src/main/java/iotd/models/ApodImage.java
+++ b/ch04/exercises/image-of-the-day/src/main/java/iotd/models/ApodImage.java
@@ -1,4 +1,4 @@
-package iotd;
+package iotd.models;
 
 public class ApodImage {
 

--- a/ch04/exercises/image-of-the-day/src/main/java/iotd/models/Image.java
+++ b/ch04/exercises/image-of-the-day/src/main/java/iotd/models/Image.java
@@ -1,4 +1,4 @@
-package iotd;
+package iotd.models;
 
 public class Image {
 

--- a/ch04/exercises/image-of-the-day/src/main/java/iotd/services/CacheService.java
+++ b/ch04/exercises/image-of-the-day/src/main/java/iotd/services/CacheService.java
@@ -1,6 +1,8 @@
-package iotd;
+package iotd.services;
 
 import java.util.ArrayList;
+
+import iotd.models.Image;
 
 public interface CacheService {
     Image getImage();

--- a/ch04/exercises/image-of-the-day/src/main/java/iotd/services/MemoryCacheService.java
+++ b/ch04/exercises/image-of-the-day/src/main/java/iotd/services/MemoryCacheService.java
@@ -1,4 +1,4 @@
-package iotd;
+package iotd.services;
 
 import java.util.concurrent.TimeUnit;
 import org.ehcache.config.CacheConfiguration;
@@ -10,6 +10,8 @@ import org.ehcache.Cache;
 import org.ehcache.expiry.Duration;
 import org.ehcache.expiry.Expirations;
 import org.springframework.stereotype.Service;
+
+import iotd.models.Image;
 
 @Service("CacheService")
 public class MemoryCacheService implements CacheService { 


### PR DESCRIPTION
When running the application as-is, I was getting exceptions:
```
ch04/exercises/image-of-the-day
❯ docker image build -t image-of-the-day .
...
❯ docker container run --name iotd -d -p 800:80 --network nat image-of-the-day
...
❯ docker container logs iotd

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::        (v2.1.3.RELEASE)

2023-01-01 14:09:01.516  INFO 1 --- [           main] iotd.Application                         : Starting Application v0.1.0 on a73b3c3cbbab with PID 1 (/app/iotd-service-0.1.0.jar started by root in /app)
2023-01-01 14:09:01.518  INFO 1 --- [           main] iotd.Application                         : No active profile set, falling back to default profiles: default
2023-01-01 14:09:01.651  WARN 1 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to parse configuration class [iotd.Application]; nested exception is org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'imageController' for bean class [iotd.ImageController] conflicts with existing, non-compatible bean definition of same name and class [iotd.controllers.ImageController]
2023-01-01 14:09:01.846 ERROR 1 --- [           main] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.BeanDefinitionStoreException: Failed to parse configuration class [iotd.Application]; nested exception is org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'imageController' for bean class [iotd.ImageController] conflicts with existing, non-compatible bean definition of same name and class [iotd.controllers.ImageController]
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:181) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.processConfigBeanDefinitions(ConfigurationClassPostProcessor.java:315) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.postProcessBeanDefinitionRegistry(ConfigurationClassPostProcessor.java:232) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanDefinitionRegistryPostProcessors(PostProcessorRegistrationDelegate.java:275) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:95) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:705) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:531) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:142) ~[spring-boot-2.1.3.RELEASE.jar!/:2.1.3.RELEASE]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:775) ~[spring-boot-2.1.3.RELEASE.jar!/:2.1.3.RELEASE]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397) ~[spring-boot-2.1.3.RELEASE.jar!/:2.1.3.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:316) ~[spring-boot-2.1.3.RELEASE.jar!/:2.1.3.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1260) ~[spring-boot-2.1.3.RELEASE.jar!/:2.1.3.RELEASE]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1248) ~[spring-boot-2.1.3.RELEASE.jar!/:2.1.3.RELEASE]
	at iotd.Application.main(Application.java:18) ~[classes!/:0.1.0]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48) ~[iotd-service-0.1.0.jar:0.1.0]
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:87) ~[iotd-service-0.1.0.jar:0.1.0]
	at org.springframework.boot.loader.Launcher.launch(Launcher.java:50) ~[iotd-service-0.1.0.jar:0.1.0]
	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:51) ~[iotd-service-0.1.0.jar:0.1.0]
Caused by: org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'imageController' for bean class [iotd.ImageController] conflicts with existing, non-compatible bean definition of same name and class [iotd.controllers.ImageController]
	at org.springframework.context.annotation.ClassPathBeanDefinitionScanner.checkCandidate(ClassPathBeanDefinitionScanner.java:348) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.annotation.ClassPathBeanDefinitionScanner.doScan(ClassPathBeanDefinitionScanner.java:286) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.annotation.ComponentScanAnnotationParser.parse(ComponentScanAnnotationParser.java:132) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassParser.doProcessConfigurationClass(ConfigurationClassParser.java:287) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassParser.processConfigurationClass(ConfigurationClassParser.java:242) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:199) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassParser.parse(ConfigurationClassParser.java:167) ~[spring-context-5.1.5.RELEASE.jar!/:5.1.5.RELEASE]
	... 21 common frames omitted
```

Then noticed that the package paths are incorrect. After this fix, it was working correctly.