### PR TITLE
🔧 fix(ch04/access-log): Fix the dependency error

### DIFF
--- a/ch04/exercises/access-log/src/package.json
+++ b/ch04/exercises/access-log/src/package.json
@@ -5,7 +5,8 @@
     "author": "Elton Stoneman",
     "dependencies": {
       "restify":"8.3.3",
-      "winston": "3.2.1"
+      "winston": "3.2.1",
+      "winston-transport": "4.3.0"
     }
   }
   


### PR DESCRIPTION
related issue: https://github.com/sixeyed/diamol/issues/69

## Problem

Exercise from `ch04/exercises/access-log` Node.JS project has failed to run.

## Solution

Added `"winston-transport": "4.3.0"` for dependencies in package.json